### PR TITLE
Remove dsname from nested value field

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,18 @@ then you get new record:
 
 Empty values in "plugin", "plugin_instance", "type" or "type_instance" will not be copied into the new tag name
 
+If a records has only one value like :
+```js
+[{"time" => 1000, "host" => 'host_v', "interval" => 5, "plugin" => 'plugin_v', "plugin_instance" => 'plugin_instance_v', "type" => 'type_v', "type_instance" => 'type_instance_v', "values" => ['v1'], "dsnames" => ['n1'], "dstypes" => ['t1']}]
+```
+then the new record will be:
+
+```js
+[{"host" => "host_v", "collectd": {"time" => 1000, "interval" => 5,
+"plugin" => "plugin_v", "plugin_instace" => "plugin_instance_v",
+"type" => "type_v", "type_instance" => "type_instance_v", "dstypes" => "t1",
+"plugin_v" => {"type_v" => "v1"}}}]
+```
 
 ## WARNING
 

--- a/README.md
+++ b/README.md
@@ -22,31 +22,41 @@ If you use fluentd
 If the following record is passed:
 
 ```js
-[{"time" => 1000, "host" => 'host_v', "interval" => 5, "plugin" => 'plugin_v', "plugin_instance" => 'plugin_instance_v', "type" => 'type_v', "type_instance" => 'type_instance_v', "values" => ['v1', 'v2'], "dsnames" => ['n1', 'n2'], "dstypes" => ['t1', 't2']}]
+{"time":1000, "host":"host_v", "interval":5, "plugin":"plugin_v", "plugin_instance":"plugin_instance_v",
+ "type":"type_v", "type_instance":"type_instance_v", "values":["v1", "v2"], "dsnames":["n1", "n2"],
+ "dstypes":["t1", "t2"]}
 ```
 
 then you get new record:
 
 ```js
-[{"host" => "host_v", "collectd": {"time" => 1000, "interval" => 5,
-"plugin" => "plugin_v", "plugin_instace" => "plugin_instance_v",
-"type" => "type_v", "type_instance" => "type_instance_v", "dstypes" => "t1",
-"plugin_v" => {"type_v" => {"n1" => "v1", "n2" => "v2"}}}}]
+{"host":"host_v",
+ "collectd": {
+   "time":1000, "interval":5, "plugin":"plugin_v", "plugin_instance":"plugin_instance_v",
+   "type":"type_v", "type_instance":"type_instance_v", "dstypes":"t1",
+   "plugin_v": {"type_v": {"n1":"v1", "n2":"v2"}}
+ }
+}
 ```
 
 Empty values in "plugin", "plugin_instance", "type" or "type_instance" will not be copied into the new tag name
 
 If a records has only one value like :
 ```js
-[{"time" => 1000, "host" => 'host_v', "interval" => 5, "plugin" => 'plugin_v', "plugin_instance" => 'plugin_instance_v', "type" => 'type_v', "type_instance" => 'type_instance_v', "values" => ['v1'], "dsnames" => ['n1'], "dstypes" => ['t1']}]
+{"time":1000, "host":"host_v", "interval":5, "plugin":"plugin_v", "plugin_instance":"plugin_instance_v",
+ "type":"type_v", "type_instance":"type_instance_v", "values":["v1"], "dsnames":["n1"],
+ "dstypes":["t1"]}
 ```
 then the new record will be:
 
 ```js
-[{"host" => "host_v", "collectd": {"time" => 1000, "interval" => 5,
-"plugin" => "plugin_v", "plugin_instace" => "plugin_instance_v",
-"type" => "type_v", "type_instance" => "type_instance_v", "dstypes" => "t1",
-"plugin_v" => {"type_v" => "v1"}}}]
+{"host":"host_v",
+ "collectd": {
+   "time":1000, "interval":5, "plugin":"plugin_v", "plugin_instance":"plugin_instance_v",
+   "type":"type_v", "type_instance":"type_instance_v", "dstypes":"t1",
+   "plugin_v": {"type_v":"v1"}
+ }
+}
 ```
 
 ## WARNING

--- a/lib/fluent/plugin/out_collectd_nest.rb
+++ b/lib/fluent/plugin/out_collectd_nest.rb
@@ -39,16 +39,19 @@ module Fluent
       if !(record.has_key?('values')) || !(record.has_key?('dsnames')) || !(record.has_key?('dstypes')) || !(record.has_key?('host')) || !(record.has_key?('plugin')) || !(record.has_key?('type'))
         return record
       end
-      new_rec = {}
-      new_rec['hostname']= record['host']
-      rec_plugin = record['plugin']
-      rec_type = record['type']
-      record[rec_plugin] = {rec_type => {}}
-
-      record['values'].each_with_index { |value, index|
-        record[rec_plugin][rec_type][record['dsnames'][index]] = value
-      }
-      record['dstypes'] = record['dstypes'].uniq
+          new_rec = {}
+          new_rec['hostname']= record['host']
+          rec_plugin = record['plugin']
+          rec_type = record['type']
+          record[rec_plugin] = {rec_type => {}}
+      if record['dsnames'].length == 1
+          record[rec_plugin][rec_type] = record['values']
+      else
+          record['values'].each_with_index { |value, index|
+          record[rec_plugin][rec_type][record['dsnames'][index]] = value
+          }
+          record['dstypes'] = record['dstypes'].uniq
+      end
       record.delete('host')
       record.delete('dsnames')
       record.delete('values')

--- a/lib/fluent/plugin/out_collectd_nest.rb
+++ b/lib/fluent/plugin/out_collectd_nest.rb
@@ -39,18 +39,18 @@ module Fluent
       if !(record.has_key?('values')) || !(record.has_key?('dsnames')) || !(record.has_key?('dstypes')) || !(record.has_key?('host')) || !(record.has_key?('plugin')) || !(record.has_key?('type'))
         return record
       end
-          new_rec = {}
-          new_rec['hostname']= record['host']
-          rec_plugin = record['plugin']
-          rec_type = record['type']
-          record[rec_plugin] = {rec_type => {}}
+      new_rec = {}
+      new_rec['hostname']= record['host']
+      rec_plugin = record['plugin']
+      rec_type = record['type']
+      record[rec_plugin] = {rec_type => {}}
       if record['dsnames'].length == 1
-          record[rec_plugin][rec_type] = record['values']
+        record[rec_plugin][rec_type] = record['values']
       else
-          record['values'].each_with_index { |value, index|
+        record['values'].each_with_index { |value, index|
           record[rec_plugin][rec_type][record['dsnames'][index]] = value
-          }
-          record['dstypes'] = record['dstypes'].uniq
+        }
+        record['dstypes'] = record['dstypes'].uniq
       end
       record.delete('host')
       record.delete('dsnames')


### PR DESCRIPTION
Removed dsname from collectd nested value field,
in case the record has only one value, since
it is always "value" and there is no need for it.

Bug-Url: https://github.com/ViaQ/fluent-plugin-collectd-nest/issues/5
Signed-off-by: Shirly Radco <sradco@redhat.com>