### PR TITLE
updated field as a string and not an array

### DIFF
--- a/lib/fluent/plugin/out_collectd_nest.rb
+++ b/lib/fluent/plugin/out_collectd_nest.rb
@@ -45,7 +45,7 @@ module Fluent
       rec_type = record['type']
       record[rec_plugin] = {rec_type => {}}
       if record['dsnames'].length == 1
-        record[rec_plugin][rec_type] = record['values']
+        record[rec_plugin][rec_type] = record['values'].first
       else
         record['values'].each_with_index { |value, index|
           record[rec_plugin][rec_type][record['dsnames'][index]] = value


### PR DESCRIPTION
Updated collectd metrics records with only one value,
so that the value that was saved as an array will
be saved as a number.

Signed-off-by: Shirly Radco <sradco@redhat.com>